### PR TITLE
fix multi-line comments

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,8 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        // symbol used for single line comment
         "lineComment": "//",
+        "blockComment": ["/*", "*/"]
     },
     // symbols used as brackets
     "brackets": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "arm-asl-server",
   "description": "Language server for ARM64 Architecture Specification Language",
   "author": "Andrew Brown",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/andrewj-brown/asl-language-server" 

--- a/syntaxes/asl.tmLanguage.json
+++ b/syntaxes/asl.tmLanguage.json
@@ -56,7 +56,7 @@
                 {
                     "comment": "comparison binary operator",
                     "name": "keyword.comparison.asl",
-                    "match": "\\s(==|!=||<=||>=)\\s"
+                    "match": "\\s(==|!=|<=|>=)\\s"
                 },
                 {
                     "comment": "bit binary operators",
@@ -85,7 +85,8 @@
                 {
                     "comment": "multi-line comment",
                     "name": "comment.multiline.asl",
-                    "match": "/\\*([.\\n]*?)\\*/"
+                    "begin": "/\\*",
+                    "end": "\\*/"
                 }
             ]
         },


### PR DESCRIPTION
Went back to before the client existed to debug multi-line comment support. Finished the multi-line comment support. Now merging the multi-line comment support back to main.